### PR TITLE
Store CSRF key, removed for GET requests

### DIFF
--- a/lib/helpers/methods.js
+++ b/lib/helpers/methods.js
@@ -1,0 +1,7 @@
+// Store the HTTP methods here.
+module.exports = {
+  get: 'GET',
+  patch: 'PATCH',
+  post: 'POST',
+  delete: 'DELETE'
+};

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -1,5 +1,6 @@
 const Base = require('./base');
 const axios = require('axios');
+const methods = require('./methods');
 
 module.exports = class Request extends Base {
   constructor(base, credentials) {
@@ -7,7 +8,9 @@ module.exports = class Request extends Base {
     // Every instance of Hydrant has a base path and base credentials.
     this.base = base;
     this.credentials = credentials;
+    this.csrfToken = null;
   }
+
   /**
    * Issue a generic XMLHttpRequest.
    * @param {string} method
@@ -33,6 +36,11 @@ module.exports = class Request extends Base {
           'X-CSRF-Token': XCSRFToken
         }
       };
+
+      // If this is a GET request, drop the CSRF Token header.
+      if (method === methods.get) {
+        delete options.headers['X-CSRF-Token'];
+      }
 
       // If we have additionalHeaders, set them.
       // @TODO: This is NOT the safest way, so be careful.
@@ -61,9 +69,15 @@ module.exports = class Request extends Base {
    *  A Promise that when fulfilled returns a response containing the X-CSRF-Token.
    */
   getXCSRFToken() {
+    if (this.csrfToken) {
+      return Promise.resolve(this.csrfToken);
+    }
     return new Promise((resolve, reject) => {
       axios({method: 'get', url: `${this.base}/rest/session/token`})
-        .then(res => resolve(res.data))
+        .then(res => {
+          this.csrfToken = res.data;
+          return resolve(res.data);
+        })
         .catch(err => reject(err));
     });
   }

--- a/lib/resources/contentType.js
+++ b/lib/resources/contentType.js
@@ -1,4 +1,5 @@
 const Request = require('../helpers/request');
+const methods = require('../helpers/methods');
 
 module.exports = class ContentType extends Request {
 
@@ -23,8 +24,7 @@ module.exports = class ContentType extends Request {
     if (typeof contentType !== 'string') {
       return Promise.reject(new Error('Expected parameter contentType must be a string'));
     }
-    return this.getXCSRFToken()
-      .then((token) => this.issueRequest('GET', `/entity/node_type/${contentType}?_format=${format}`, token));
+    return this.issueRequest(methods.get, `/entity/node_type/${contentType}?_format=${format}`, '');
   }
 
   /**
@@ -42,7 +42,7 @@ module.exports = class ContentType extends Request {
       return Promise.reject(new Error('Expected parameter entityId must be a number'));
     }
     return this.getXCSRFToken()
-      .then((token) => this.issueRequest('PATCH', `/entity/node_type/${contentType}?_format=${format}`, token, {}, body));
+      .then((token) => this.issueRequest(methods.patch, `/entity/node_type/${contentType}?_format=${format}`, token, {}, body));
   }
 
   /**
@@ -58,7 +58,7 @@ module.exports = class ContentType extends Request {
       return Promise.reject(new Error('Expected parameter body must be an Object'));
     }
     return this.getXCSRFToken()
-      .then((token) => this.issueRequest('POST', '/entity/node_type', token, {'Content-type': 'application/json'}, body));
+      .then((token) => this.issueRequest(methods.post, '/entity/node_type', token, {'Content-type': 'application/json'}, body));
   }
 
   /**
@@ -72,7 +72,7 @@ module.exports = class ContentType extends Request {
       return Promise.reject(new Error('Expected parameter contentType must be a string'));
     }
     return this.getXCSRFToken()
-      .then((token) => this.issueRequest('DELETE', `/entity/node_type/${contentType}`, token));
+      .then((token) => this.issueRequest(methods.delete, `/entity/node_type/${contentType}`, token));
   }
 
 };

--- a/lib/resources/menu.js
+++ b/lib/resources/menu.js
@@ -1,4 +1,5 @@
 const Request = require('../helpers/request');
+const methods = require('../helpers/methods');
 
 module.exports = class Menu extends Request {
 
@@ -23,8 +24,7 @@ module.exports = class Menu extends Request {
     if (typeof menuName !== 'string') {
       return Promise.reject(new Error('Expected parameter menuName must be a string'));
     }
-    return this.getXCSRFToken()
-      .then((token) => this.issueRequest('GET', `entity/menu/${menuName}?_format=${format}`, token));
+    return this.issueRequest(methods.get, `entity/menu/${menuName}?_format=${format}`, '');
   }
 
   /**
@@ -42,7 +42,7 @@ module.exports = class Menu extends Request {
       return Promise.reject(new Error('Expected parameter entityId must be a number'));
     }
     return this.getXCSRFToken()
-      .then((token) => this.issueRequest('PATCH', `entity/menu/${menuName}?_format=${format}`, token, {}, body));
+      .then((token) => this.issueRequest(methods.patch, `entity/menu/${menuName}?_format=${format}`, token, {}, body));
   }
 
   /**
@@ -58,7 +58,7 @@ module.exports = class Menu extends Request {
       return Promise.reject(new Error('Expected parameter body must be an Object'));
     }
     return this.getXCSRFToken()
-      .then((token) => this.issueRequest('POST', 'entity/menu', token, {'Content-type': 'application/json'}, body));
+      .then((token) => this.issueRequest(methods.post, 'entity/menu', token, {'Content-type': 'application/json'}, body));
   }
 
   /**
@@ -72,7 +72,7 @@ module.exports = class Menu extends Request {
       return Promise.reject(new Error('Expected parameter menuName must be a string'));
     }
     return this.getXCSRFToken()
-      .then((token) => this.issueRequest('DELETE', `entity/menu/${menuName}`, token));
+      .then((token) => this.issueRequest(methods.delete, `entity/menu/${menuName}`, token));
   }
 
 };

--- a/lib/resources/node.js
+++ b/lib/resources/node.js
@@ -1,4 +1,5 @@
 const Request = require('../helpers/request');
+const methods = require('../helpers/methods');
 
 module.exports = class Node extends Request {
 
@@ -23,8 +24,7 @@ module.exports = class Node extends Request {
     if (!Number.isInteger(entityId)) {
       return Promise.reject(new Error('Expected parameter entityId must be a number'));
     }
-    return this.getXCSRFToken()
-      .then((token) => this.issueRequest('GET', `node/${entityId}?_format=${format}`, token));
+    return this.issueRequest(methods.get, `node/${entityId}?_format=${format}`, '');
   }
 
   /**
@@ -42,7 +42,7 @@ module.exports = class Node extends Request {
       return Promise.reject(new Error('Expected parameter entityId must be a number'));
     }
     return this.getXCSRFToken()
-      .then((token) => this.issueRequest('PATCH', `node/${entityId}?_format=${format}`, token, {}, body));
+      .then((token) => this.issueRequest(methods.patch, `node/${entityId}?_format=${format}`, token, {}, body));
   }
 
   /**
@@ -58,7 +58,7 @@ module.exports = class Node extends Request {
       return Promise.reject(new Error('Expected parameter body must be an Object'));
     }
     return this.getXCSRFToken()
-      .then((token) => this.issueRequest('POST', 'entity/node', token, {'Content-type': 'application/json'}, body));
+      .then((token) => this.issueRequest(methods.post, 'entity/node', token, {'Content-type': 'application/json'}, body));
   }
 
   /**
@@ -72,7 +72,7 @@ module.exports = class Node extends Request {
       return Promise.reject(new Error('Expected parameter entityId must be a number'));
     }
     return this.getXCSRFToken()
-      .then((token) => this.issueRequest('DELETE', `node/${entityId}`, token));
+      .then((token) => this.issueRequest(methods.delete, `node/${entityId}`, token));
   }
 
 };

--- a/test/index.js
+++ b/test/index.js
@@ -125,6 +125,20 @@ module.exports = {
             test.equal(err, 'bar', 'Unexpected response.');
             test.done();
           });
+      },
+      cacheCSRF: test => {
+        test.expect(1);
+
+        const Request = requireSubvert.require('../lib/helpers/request');
+        const request = new Request('http://foo.dev', {user: 'a', pass: 'b'});
+
+        request.csrfToken = '1234';
+
+        request.getXCSRFToken()
+          .then(res => {
+            test.equal(res, '1234', 'Unexpected response.');
+            test.done();
+          });
       }
     },
     headers: test => {
@@ -139,12 +153,12 @@ module.exports = {
 
       request.issueRequest('GET', '/entity/1', '12345', {})
         .then(res => {
-          test.deepEqual({'X-CSRF-Token': '12345'}, res, 'Unexpected headers returned.');
+          test.deepEqual({}, res, 'Unexpected headers returned.');
         });
 
       request.issueRequest('GET', '/entity/1', '34567', {'foo': 'bar'})
         .then(res => {
-          test.deepEqual({'X-CSRF-Token': '34567', 'foo': 'bar'}, res, 'Unexpected headers set.');
+          test.deepEqual({'foo': 'bar'}, res, 'Unexpected headers set.');
           test.done();
         });
     },


### PR DESCRIPTION
![](https://media.giphy.com/media/5Tj2lxqph3dcc/giphy.gif)
- Standardize methods.
- Store the `CSRF` key for multiple sequential requests.
- Drop the need for `CSRF` keys on `GET` requests.
- Keep it 💯 on tests.
